### PR TITLE
Fix scrolling when mouse over, added scroll snapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
     <div id="timeline_container">
         <header>
-            <figure>
+            <figure class="snap">
                 <img src="https://i.pinimg.com/originals/e5/dc/07/e5dc07105ef10c7dc1cd7f858bb0c353.jpg">
             </figure>
             <h1>MCU<br>Countdown</h1>

--- a/script.js
+++ b/script.js
@@ -1,14 +1,7 @@
-function showNext(li){
-	var $itms=$('div#timeline_container li');
-	$('html,body').stop().animate({ scrollTop: $(li).offset().top-$(li).height() / 3}, 500,function(){
-		$('html,body').stop();
-	});
-}
-
 function movieToElement(movie) {
-    element = `<li class="event active" onmouseover="showNext(this)">
+    element = `<li class="event active" >
                 <div class="event_icn icon-space"></div>
-                <div class="event_content">
+                <div class="event_content snap">
                     <h2>${movie.title} (${movie.days_until} days)</h2>
                     <img src="${movie.poster_url}" alt="${movie.title} poster">
                     <p>

--- a/style.css
+++ b/style.css
@@ -225,3 +225,12 @@ div#timeline_container > ul > li:nth-child(even) div.event_date {text-align:left
 div#timeline_container > ul > li:hover div.event_date,div#timeline_container > ul li.active div.event_date {opacity:0.9;}
 div#timeline_container > ul > li:nth-child(odd) div.event_date {right:60px;}
 div#timeline_container > ul > li:nth-child(even) div.event_date {left:60px;}
+
+html,body{
+	scroll-snap-type: y mandatory;
+	scroll-snap-stop: always;
+}
+
+.snap{
+	scroll-snap-align: center;
+}


### PR DESCRIPTION
### Issue with scrolling:
Scrolling while hovering over a movie card creates unexpected behavior.
So my pull request does the following:
- removes the ```onmouseover``` event
- adds snap scrolling using CSS to somewhat preserve the functionality.
_note: if you don't like the harsh scrolling try changing ```scroll-snap-type: y mandatory;``` to ```scroll-snap-type: y proximity;_